### PR TITLE
Fix `NameError: name 'Body' is not defined. Did you mean: 'TBody'?`

### DIFF
--- a/aiostalk.py
+++ b/aiostalk.py
@@ -77,7 +77,7 @@ class Client:
         id, size = (int(n) for n in await self._send_cmd(cmd, expected))
         chunk = await self._read_chunk(size)
         if self.encoding is None:
-            body = chunk  # type: Body
+            body = chunk  # type: TBody
         else:
             body = chunk.decode(self.encoding)
         return Job(id, body)
@@ -96,7 +96,7 @@ class Client:
         return _parse_list(chunk)
 
     async def put(self,
-            body: Body,
+            body: TBody,
             priority: int = DEFAULT_PRIORITY,
             delay: int = DEFAULT_DELAY,
             ttr: int = DEFAULT_TTR) -> int:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-greenstalk>=2.0.2
+greenstalk>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='https://github.com/koodaamo/aiostalk',
     license='MIT',
     py_modules=['aiostalk'],
-    install_requires=['greenstalk>=2.0.2'],
+    install_requires=['greenstalk>=2.1.0'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Due to the new version of greenstalk changing `Body` to `TBody`, the `NameError: name 'Body' is not defined. Did you mean: 'TBody'?` error is displayed breaking any application that imports aiostalk.